### PR TITLE
fix: Tag beta releases in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,17 @@ jobs:
 
       - name: Bump release version
         if: startsWith(github.event.inputs.release-level, 'pre') != true
-        run: echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_LEVEL)" >> $GITHUB_ENV
+        run: |
+          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_LEVEL)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
         env:
           RELEASE_LEVEL: ${{ github.event.inputs.release-level }}
 
       - name: Bump pre-release version
         if: startsWith(github.event.inputs.release-level, 'pre')
-        run: echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_LEVEL)" >> $GITHUB_ENV
+        run: |
+          echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_LEVEL)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
         env:
           RELEASE_LEVEL: ${{ github.event.inputs.release-level }}
 
@@ -63,7 +67,7 @@ jobs:
 
       # Publish version to public repository
       - name: Publish
-        run: yarn publish --verbose --access public
+        run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_BOT_PAT }}
 


### PR DESCRIPTION
## Description

Tags beta releases as such so they don't get pulled by latest tag

## Motivation and Context

Beta versions got tagged as latest and it caused some mishaps

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have updated the documentation accordingly. If you are changing code related to user secrets you need to really make sure that security documentation is correct.
- [ ] I have read the CONTRIBUTION_GUIDE document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.